### PR TITLE
Add min base quality and adaptive pruning options

### DIFF
--- a/tasks/germline_calling.wdl
+++ b/tasks/germline_calling.wdl
@@ -11,6 +11,8 @@ task haplotypecaller {
         String annotation_args = ""
         Boolean gvcf_mode = false
         Boolean use_best_practices = false
+        Boolean mutect2_pruning = false
+        Int? min_base_qual = 10
         Int n_threads = 24
         Int gb_ram = 120
         Int disk_gb = 0
@@ -39,6 +41,8 @@ task haplotypecaller {
         --in-bam ~{input_bam} \
         --ref ~{ref} \
         --out-variants ~{out_vcf} \
+        --min-base-quality-score ~{min_base_qual} \
+        ~{if mutect2_pruning then "--adaptive-pruning " else ""} \
         ~{"--in-recal-file " + input_recal} \
         ~{if gvcf_mode then "--gvcf " else ""} \
         ~{"--haplotypecaller-options " + "\"" + haplotypecaller_passthrough_options + "\""
@@ -67,6 +71,7 @@ task deepvariant {
         File input_bai
         File input_ref_tarball
         Boolean gvcf_mode = false
+        Int? min_base_qual = 10
         Int n_threads = 24
         Int gb_ram = 120
         Int disk_gb = 0
@@ -84,6 +89,7 @@ task deepvariant {
         tar xvf ~{input_ref_tarball} && \
         pbrun deepvariant \
         ~{if gvcf_mode then "--gvcf " else ""} \
+        --min-base-quality ~{min_base_qual} \
         --ref ~{ref} \
         --in-bam ~{input_bam} \
         --out-variants ~{out_vcf}

--- a/workflows/germline_calling.wdl
+++ b/workflows/germline_calling.wdl
@@ -21,10 +21,13 @@ workflow germline {
         String? haplotypecaller_passthrough_options
         Boolean run_deep_variant = true
         Boolean run_haplotype_caller = true
-        ## Run both DeepVariant and haplotype_caller in gVCF mode
-        Boolean gvcf_mode = false
+        Boolean mutect2_pruning
 
-        ## DeepVariant Runtime Args
+        ## Run both tools in gVCF mode and with minimum base quality
+        Boolean gvcf_mode = false
+        Int? min_base_qual
+
+        ## Runtime Args
         Int n_threads_deep_variant = 24
         Int gb_ram_deep_variant = 120
         Int disk_gb_deep_variant = 0
@@ -40,6 +43,8 @@ workflow germline {
             input_recal = input_recal,
             input_ref_tarball = input_ref_tarball,
             gvcf_mode = gvcf_mode,
+            min_base_qual = min_base_qual,
+            mutect2_pruning = mutect2_pruning,
             haplotypecaller_passthrough_options = haplotypecaller_passthrough_options,
             n_threads = n_threads_haplotype_caller,
             gb_ram = gb_ram_haplotype_caller,
@@ -54,6 +59,7 @@ workflow germline {
             input_bai = input_bai,
             input_ref_tarball = input_ref_tarball,
             gvcf_mode = gvcf_mode,
+            min_base_qual = min_base_qual,
             n_threads = n_threads_deep_variant,
             gb_ram = gb_ram_deep_variant,
             disk_gb = disk_gb_deep_variant,


### PR DESCRIPTION
The min base quality applies to DeepVariant and HaplotypeCaller. The adaptive pruning applies to HaploType caller and uses the Mutect2 algorithm to prune the graph used to call variants.